### PR TITLE
Add contract utilization reporting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ContractPlan
+
+This project uses Next.js and TypeScript.
+
+## Development Setup
+
+1. Install Node.js 18 or higher.
+2. Run `./setup_env.sh` to install npm dependencies.
+3. Execute `npm run dev` to start the local server.
+
+Run `npm run lint` to check code quality. The lint command relies on the ESLint configuration provided in `.eslintrc.json`.

--- a/app/reports/utilization.tsx
+++ b/app/reports/utilization.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Table,
+  TableHead,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+
+// Mock contract spend data
+const contracts = [
+  { id: 'C-1001', name: 'IT Support Services', budget: 50000, actual: 48000 },
+  { id: 'C-1002', name: 'Facilities Maintenance', budget: 75000, actual: 82500 },
+  { id: 'C-1003', name: 'Community Outreach Grant', budget: 60000, actual: 45000 },
+];
+
+function calculateTotals() {
+  const totalBudget = contracts.reduce((sum, c) => sum + c.budget, 0);
+  const totalActual = contracts.reduce((sum, c) => sum + c.actual, 0);
+  return { totalBudget, totalActual };
+}
+
+function getAiRecommendation(role: 'buyer' | 'seller', delta: number) {
+  if (delta > 0) {
+    return role === 'buyer'
+      ? 'Overspend detected. Consider scaling back services or renegotiating rates.'
+      : 'Overspend detected. Increase deliverables or request a budget amendment.';
+  }
+  if (delta < 0) {
+    return role === 'buyer'
+      ? 'Underspend noted. Evaluate if additional value can be captured.'
+      : 'Underspend noted. You may reduce effort or propose reallocating funds.';
+  }
+  return 'On target. Maintain current pace.';
+}
+
+export default function UtilizationReports() {
+  const [role, setRole] = useState<'buyer' | 'seller'>('buyer');
+  const { totalBudget, totalActual } = calculateTotals();
+  const totalDelta = totalActual - totalBudget;
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Contract Utilization</h1>
+        <button
+          className="text-sm underline text-blue-600"
+          onClick={() => setRole(role === 'buyer' ? 'seller' : 'buyer')}
+        >
+          Switch to {role === 'buyer' ? 'Seller' : 'Buyer'} View
+        </button>
+      </div>
+
+      <Card>
+        <CardContent>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableHeader>Contract</TableHeader>
+                <TableHeader>Budget</TableHeader>
+                <TableHeader>Actual</TableHeader>
+                <TableHeader>Variance</TableHeader>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {contracts.map((c) => {
+                const delta = c.actual - c.budget;
+                const recommendation = getAiRecommendation(role, delta);
+                return (
+                  <TableRow key={c.id}>
+                    <TableCell>{c.name}</TableCell>
+                    <TableCell>${c.budget.toLocaleString()}</TableCell>
+                    <TableCell>${c.actual.toLocaleString()}</TableCell>
+                    <TableCell className={delta > 0 ? 'text-red-600' : delta < 0 ? 'text-yellow-600' : 'text-green-600'}>
+                      {delta > 0 ? '+' : ''}{delta.toLocaleString()}
+                      <div className="text-xs text-gray-500">{recommendation}</div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              <TableRow>
+                <TableCell className="font-semibold">Total</TableCell>
+                <TableCell className="font-semibold">${totalBudget.toLocaleString()}</TableCell>
+                <TableCell className="font-semibold">${totalActual.toLocaleString()}</TableCell>
+                <TableCell className={`font-semibold ${totalDelta > 0 ? 'text-red-600' : totalDelta < 0 ? 'text-yellow-600' : 'text-green-600'}` }>
+                  {totalDelta > 0 ? '+' : ''}{totalDelta.toLocaleString()}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4">
+          <div className="text-sm text-gray-500 mb-2">Overall Recommendation</div>
+          <p>{getAiRecommendation(role, totalDelta)}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/components/ScreenshotCarousel.tsx
+++ b/components/ScreenshotCarousel.tsx
@@ -24,7 +24,7 @@ export function ScreenshotCarousel() {
         {screenshots.map((_, i) => (
           <button
             key={i}
-            className={\`w-3 h-3 rounded-full \${i === index ? 'bg-emerald' : 'bg-gray-300'}\`}
+            className={`w-3 h-3 rounded-full ${i === index ? 'bg-emerald' : 'bg-gray-300'}`}
             onClick={() => setIndex(i)}
           />
         ))}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import { cva } from 'class-variance-authority'
+import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 import { ButtonHTMLAttributes, forwardRef } from 'react'
 
@@ -25,10 +25,7 @@ const buttonVariants = cva(
   }
 )
 
-export const Button = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: keyof typeof buttonVariants['variants']['variant']
-  size?: keyof typeof buttonVariants['variants']['size']
-}>(
+export const Button = forwardRef<HTMLButtonElement, ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>>(
   ({ className, variant, size, ...props }, ref) => {
     return (
       <button ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -21,7 +21,9 @@ export function TableRow({ children }: { children: ReactNode }) {
   return <tr className="hover:bg-gray-50">{children}</tr>;
 }
 
-export function TableCell({ children }: { children: ReactNode }) {
-  return <td className="px-4 py-2 text-sm text-gray-700 border-b">{children}</td>;
+export function TableCell({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <td className={`px-4 py-2 text-sm text-gray-700 border-b ${className}`}>{children}</td>
+  );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "contractplan",
       "version": "1.0.0",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.0",
         "lucide-react": "^0.525.0",
@@ -1581,6 +1582,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/client-only": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.0",
     "lucide-react": "^0.525.0",

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -d node_modules ]; then
+  echo "Installing npm dependencies..."
+  npm install
+else
+  echo "Dependencies already installed."
+fi


### PR DESCRIPTION
## Summary
- track spending per contract with AI recommendations
- allow buyer vs seller role toggle in report
- include class variance dependency and type-safe button
- enable styling of table cells

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f805cda108326b5504f041abc060c